### PR TITLE
Add docs for installing and developing MCP

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Thanks for wanting to contribute! Follow these guidelines to set up your environ
    ```
 2. Install the project with development dependencies:
    ```bash
-   pip install -e .[dev,test]
+pip install -e .[dev]
    ```
 3. Install pre-commit hooks:
    ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,7 @@ Thanks for wanting to contribute! Follow these guidelines to set up your environ
    ```
 2. Install the project with development dependencies:
    ```bash
-   pip install -e .
-   pip install pre-commit pytest pytest-asyncio
+   pip install -e .[dev,test]
    ```
 3. Install pre-commit hooks:
    ```bash
@@ -28,7 +27,7 @@ Thanks for wanting to contribute! Follow these guidelines to set up your environ
 - Compile the code and run tests:
   ```bash
   python -m py_compile fast_precommit_mcp/*.py
-  pytest
+  pytest --cov=fast_precommit_mcp --cov-report=term-missing
   ```
 
 GitHub Actions will run these same checks on every pull request.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,28 @@
 
 This repository contains a demonstration MCP server built with [FastMCP](https://pypi.org/project/fastmcp/). The server runs `pre-commit` once when it starts and then reruns it whenever files change. Output is streamed to connected MCP clients and can also be refreshed on demand using a tool.
 
+## Installation
+
+Install directly from GitHub with pip:
+
+```bash
+pip install git+https://github.com/jonzarecki/pre-commit-mcp
+```
+
+Run the server with `npx` without needing a system-wide install:
+
+```bash
+npx --yes github:jonzarecki/pre-commit-mcp
+```
+
+Or clone the repository and install in editable mode for development:
+
+```bash
+git clone https://github.com/jonzarecki/pre-commit-mcp.git
+cd pre-commit-mcp
+pip install -e .
+```
+
 ## Usage
 
 Run the server:
@@ -17,3 +39,18 @@ Available tools:
 - `run_precommit_tool` – Executes `pre-commit run` (optionally on specific files) and streams log lines back to the client.
 
 The latest pre-commit output is also available as a resource named `precommit-output`.
+
+## MCP client configuration
+
+To let an MCP client automatically install and launch the server, add the following to `mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "fast-precommit-mcp": {
+      "command": "npx --yes github:jonzarecki/pre-commit-mcp",
+      "env": {}
+    }
+  }
+}
+```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Or clone the repository and install in editable mode for development:
 ```bash
 git clone https://github.com/jonzarecki/pre-commit-mcp.git
 cd pre-commit-mcp
-pip install -e .
+pip install -e .[dev]
 ```
 
 ## Usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,14 @@ dependencies = ["fastmcp", "watchfiles"]
 test = [
     "pytest",
     "pytest-asyncio",
+    "pytest-cov",
+]
+
+dev = [
+    "pre-commit",
+    "pytest",
+    "pytest-asyncio",
+    "pytest-cov",
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
## Summary
- document installation including `pip`/`npx` options and mcp.json example
- update CONTRIBUTING with development install and coverage instructions
- add `dev` optional dependencies

## Testing
- `pre-commit run --files README.md CONTRIBUTING.md pyproject.toml`
- `python3 -m py_compile fast_precommit_mcp/*.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687cb68bb5a0832aab88442c1de85259